### PR TITLE
chore(deps): 不需要限制 tzdata 的版本

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -975,7 +975,7 @@ python-versions = ">=3.7"
 
 [[package]]
 name = "tzdata"
-version = "2021.5"
+version = "2022.1"
 description = "Provider of IANA time zone data"
 category = "main"
 optional = false
@@ -1106,7 +1106,7 @@ multidict = ">=4.0"
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.8"
-content-hash = "c1132003d569feb523ca7ed131067456765229b99a3f90c5610dd7555e47fec4"
+content-hash = "60e621c0e9ee14ec5bfcd03aef0aaf52b0b6855745b54ae682899bc787fc4609"
 
 [metadata.files]
 aiosqlite = [
@@ -1866,8 +1866,8 @@ typing-extensions = [
     {file = "typing_extensions-4.2.0.tar.gz", hash = "sha256:f1c24655a0da0d1b67f07e17a5e6b2a105894e6824b92096378bb3668ef02376"},
 ]
 tzdata = [
-    {file = "tzdata-2021.5-py2.py3-none-any.whl", hash = "sha256:3eee491e22ebfe1e5cfcc97a4137cd70f092ce59144d81f8924a844de05ba8f5"},
-    {file = "tzdata-2021.5.tar.gz", hash = "sha256:68dbe41afd01b867894bbdfd54fa03f468cfa4f0086bfb4adcd8de8f24f3ee21"},
+    {file = "tzdata-2022.1-py2.py3-none-any.whl", hash = "sha256:238e70234214138ed7b4e8a0fab0e5e13872edab3be586ab8198c407620e2ab9"},
+    {file = "tzdata-2022.1.tar.gz", hash = "sha256:8b536a8ec63dc0751342b3984193a3118f8fca2afe25752bb9b7fffd398552d3"},
 ]
 urllib3 = [
     {file = "urllib3-1.26.9-py2.py3-none-any.whl", hash = "sha256:44ece4d53fb1706f667c9bd1c648f5469a2ec925fcf3a776667042d645472c14"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ nonebot-adapter-onebot = "^2.0.0-beta.1"
 nonebot-plugin-chatrecorder = "^0.1.5"
 wordcloud = "^1.8.1"
 jieba = "^0.42.1"
-tzdata = "^2021.5"
+tzdata = "*"
 "backports.zoneinfo" = {version = "^0.2.1", markers = "python_version < '3.9'" }
 emoji = "^1.6.3"
 


### PR DESCRIPTION
tzdata 每年都会更新好几次，完全没有必要限制这个包的版本。