### PR TITLE
improve: 将函数放在执行器中运行防止生成词云时阻塞事件循环

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Changed
+
+- 防止生成词云时卡住，将函数放在执行器中运行
+
 ## [0.2.0] - 2022-05-25
 
 ### Changed

--- a/nonebot_plugin_wordcloud/__init__.py
+++ b/nonebot_plugin_wordcloud/__init__.py
@@ -6,6 +6,8 @@ from inspect import cleandoc
 from io import BytesIO
 from typing import Tuple, Union
 
+from nonebot.utils import run_sync
+
 try:
     from zoneinfo import ZoneInfo
 except ImportError:
@@ -208,7 +210,7 @@ async def handle_message(
         time_stop=stop.astimezone(ZoneInfo("UTC")),
         plain_text=True,
     )
-    image = get_wordcloud(messages)
+    image = await run_sync(get_wordcloud)(messages)
     if image:
         image_bytes = BytesIO()
         image.save(image_bytes, format="PNG")


### PR DESCRIPTION
之前一直没注意到生成词云是一个同步函数，并且特别耗时。

```log
05-25 09:31:10 [INFO] nonebot | Event will be handled by <Matcher from nonebot_plugin_wordcloud, type=message, priority=1, temp=False>
05-25 09:31:21 [WARNING] apscheduler | Run time of job "fetch_and_send (trigger: interval[0:00:03], next run at: 2022-05-25 09:31:21 CST)" was missed by 0:00:02.711566
05-25 09:31:21 [WARNING] apscheduler | Run time of job "fetch_and_send (trigger: interval[0:00:30], next run at: 2022-05-25 09:31:45 CST)" was missed by 0:00:05.725239
05-25 09:31:21 [WARNING] apscheduler | Run time of job "fetch_and_send (trigger: interval[0:00:10], next run at: 2022-05-25 09:31:25 CST)" was missed by 0:00:05.726096
05-25 09:31:21 [WARNING] apscheduler | Run time of job "fetch_and_send (trigger: interval[0:01:00], next run at: 2022-05-25 09:32:15 CST)" was missed by 0:00:05.725754
05-25 09:31:21 [WARNING] apscheduler | Run time of job "fetch_and_send (trigger: interval[0:01:00], next run at: 2022-05-25 09:32:15 CST)" was missed by 0:00:05.726137
05-25 09:31:21 [WARNING] apscheduler | Run time of job "fetch_and_send (trigger: interval[0:00:30], next run at: 2022-05-25 09:31:45 CST)" was missed by 0:00:05.724116
05-25 09:31:23 [INFO] nonebot | Matcher <Matcher from nonebot_plugin_wordcloud, type=message, priority=1, temp=False> running complete
```