### PR TITLE
fix: 修复发送 `/词云` 后帮助信息为空的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复发送 `/词云` 后帮助信息为空的问题
+
 ## [0.3.0] - 2022-10-06
 
 ### Added

--- a/nonebot_plugin_wordcloud/__init__.py
+++ b/nonebot_plugin_wordcloud/__init__.py
@@ -156,8 +156,7 @@ async def handle_first_receive(
         plaintext = args.extract_plain_text()
         # 当完整匹配词云的时候才输出帮助信息
         if not plaintext:
-            help_msg = cleandoc(wordcloud_cmd.__doc__) if wordcloud_cmd.__doc__ else ""
-            await wordcloud_cmd.finish(help_msg)
+            await wordcloud_cmd.finish(__plugin_meta__.usage)
         else:
             await wordcloud_cmd.finish()
 

--- a/tests/test_wordcloud.py
+++ b/tests/test_wordcloud.py
@@ -99,7 +99,7 @@ async def test_wordcloud_help(app: App):
     """测试输出帮助信息"""
     from nonebot.adapters.onebot.v11 import Message
 
-    from nonebot_plugin_wordcloud import cleandoc, wordcloud_cmd
+    from nonebot_plugin_wordcloud import __plugin_meta__, wordcloud_cmd
 
     async with app.test_matcher(wordcloud_cmd) as ctx:
         bot = ctx.create_bot()
@@ -108,7 +108,7 @@ async def test_wordcloud_help(app: App):
         ctx.receive_event(bot, event)
         ctx.should_call_send(
             event,
-            cleandoc(wordcloud_cmd.__doc__) if wordcloud_cmd.__doc__ else "",
+            __plugin_meta__.usage,
             True,
         )
         ctx.should_finished()


### PR DESCRIPTION
上次更新 metadata 之后一直没注意到 __doc__ 已经不存在了。