### PR TITLE
fix: 修复 OneBot 适配器依赖问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复 OneBot 适配器依赖问题
+
 ## [0.4.1] - 2023-01-23
 
 ### Fixed

--- a/poetry.lock
+++ b/poetry.lock
@@ -2906,4 +2906,4 @@ testing = ["coverage (>=5.0.3)", "zope.event", "zope.testing"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8"
-content-hash = "a7e7cee9d23916136c0d654de48327846eacd891b4c6e56b1e7723a97cda79a7"
+content-hash = "a26679fc629a9936235eebee184ecd413b64cd94f6037bfc88a69bc79c5b864d"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ documentation = "https://github.com/he0119/nonebot-plugin-wordcloud#readme"
 [tool.poetry.dependencies]
 python = "^3.8"
 nonebot2 = { version = "^2.0.0-rc.1", extras = ["fastapi"] }
-nonebot-adapter-onebot = "^2.0.0-beta.1"
+nonebot-adapter-onebot = "^2.2.0"
 nonebot-plugin-chatrecorder = "^0.2.0"
 wordcloud = "^1.8.1"
 jieba = "^0.42.1"


### PR DESCRIPTION
2.2.0 版本以后才有可用的 onebot 12 适配器。

closed #94