### PR TITLE
docs: wordcloud_timezone 配置说明添加时区列表及示例

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,8 @@ _✨ NoneBot 词云插件 ✨_
 
 - 类型: `str`
 - 默认: `None`
-- 说明: 用户自定义的 [时区](https://docs.python.org/zh-cn/3/library/zoneinfo.html)，留空则使用系统时区
+- 说明: 用户自定义的 [时区](https://docs.python.org/zh-cn/3/library/zoneinfo.html)，留空则使用系统时区, 时区列表可参考：[time-zones](https://timezonedb.com/time-zones)
+- Example: `Asia/Shanghai`
 
 ### wordcloud_default_schedule_time
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ _✨ NoneBot 词云插件 ✨_
 
 - 类型: `str`
 - 默认: `None`
-- 说明: 用户自定义的 [时区](https://docs.python.org/zh-cn/3/library/zoneinfo.html)，留空则使用系统时区, 时区列表可参考：[时区列表](https://timezonedb.com/time-zones), Example: `Asia/Shanghai`
+- 说明: 用户自定义的 [时区](https://docs.python.org/zh-cn/3/library/zoneinfo.html)，留空则使用系统时区, 时区列表可参考：[时区列表](https://timezonedb.com/time-zones), 比如说: `Asia/Shanghai`
 
 ### wordcloud_default_schedule_time
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ _✨ NoneBot 词云插件 ✨_
 
 - 类型: `str`
 - 默认: `None`
-- 说明: 用户自定义的 [时区](https://docs.python.org/zh-cn/3/library/zoneinfo.html)，留空则使用系统时区, 时区列表可参考：[time-zones](https://timezonedb.com/time-zones), Example: `Asia/Shanghai`
+- 说明: 用户自定义的 [时区](https://docs.python.org/zh-cn/3/library/zoneinfo.html)，留空则使用系统时区, 时区列表可参考：[时区列表](https://timezonedb.com/time-zones), Example: `Asia/Shanghai`
 
 ### wordcloud_default_schedule_time
 

--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ _✨ NoneBot 词云插件 ✨_
 
 - 类型: `str`
 - 默认: `None`
-- 说明: 用户自定义的 [时区](https://docs.python.org/zh-cn/3/library/zoneinfo.html)，留空则使用系统时区, 时区列表可参考：[时区列表](https://timezonedb.com/time-zones), 比如说: `Asia/Shanghai`
+- 说明: 用户自定义的 [时区](https://docs.python.org/zh-cn/3/library/zoneinfo.html)，留空则使用系统时区，时区列表可参考：[时区列表](https://timezonedb.com/time-zones)，比如说：`Asia/Shanghai`
 
 ### wordcloud_default_schedule_time
 

--- a/README.md
+++ b/README.md
@@ -94,8 +94,7 @@ _✨ NoneBot 词云插件 ✨_
 
 - 类型: `str`
 - 默认: `None`
-- 说明: 用户自定义的 [时区](https://docs.python.org/zh-cn/3/library/zoneinfo.html)，留空则使用系统时区, 时区列表可参考：[time-zones](https://timezonedb.com/time-zones)
-- Example: `Asia/Shanghai`
+- 说明: 用户自定义的 [时区](https://docs.python.org/zh-cn/3/library/zoneinfo.html)，留空则使用系统时区, 时区列表可参考：[time-zones](https://timezonedb.com/time-zones), Example: `Asia/Shanghai`
 
 ### wordcloud_default_schedule_time
 


### PR DESCRIPTION
添加时区说明，
感觉直接指定utc-8会更清晰点，但大部分用户应该不会用到这个字段