### PR TITLE
feat: 支持排除特定用户

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 ### Added
 
 - 支持直接向词云传递参数
+- 支持排除特定用户
 
 ### Fixed
 

--- a/README.md
+++ b/README.md
@@ -107,3 +107,9 @@ _✨ NoneBot 词云插件 ✨_
 - 类型: `Dict[str, Any]`
 - 默认: `{}`
 - 说明: 向 [WordCloud](https://amueller.github.io/word_cloud/generated/wordcloud.WordCloud.html#wordcloud.WordCloud) 传递的参数。拥有最高优先级，将会覆盖以上词云的配置项。
+
+### wordcloud_exclude_user_ids
+
+- 类型: `Set[str]`
+- 默认: `set()`
+- 说明: 排除的用户 ID 列表（全局，不区分平台）。

--- a/nonebot_plugin_wordcloud/__init__.py
+++ b/nonebot_plugin_wordcloud/__init__.py
@@ -241,6 +241,7 @@ async def handle_get_messages_group_message(
         types=["message"],  # 排除机器人自己发的消息
         time_start=start.astimezone(ZoneInfo("UTC")),
         time_stop=stop.astimezone(ZoneInfo("UTC")),
+        exclude_user_ids=plugin_config.wordcloud_exclude_user_ids,
     )
     state["mask_key"] = (
         get_mask_key("qq", group_id=event.group_id)
@@ -275,6 +276,7 @@ async def handle_get_messages_channel_message(
         types=["message"],
         time_start=start.astimezone(ZoneInfo("UTC")),
         time_stop=stop.astimezone(ZoneInfo("UTC")),
+        exclude_user_ids=plugin_config.wordcloud_exclude_user_ids,
     )
     state["mask_key"] = get_mask_key(bot.platform, guild_id=event.guild_id)
 

--- a/nonebot_plugin_wordcloud/config.py
+++ b/nonebot_plugin_wordcloud/config.py
@@ -1,6 +1,6 @@
 from datetime import datetime, time
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Set
 
 from nonebot import get_driver
 from nonebot_plugin_datastore import get_plugin_data
@@ -29,6 +29,8 @@ class Config(BaseModel, extra=Extra.ignore):
     如果群内不单独设置则使用这个值，默认为晚上 10 点，时区为设定的时区
     """
     wordcloud_options: Dict[str, Any] = {}
+    wordcloud_exclude_user_ids: Set[str] = set()
+    """排除的用户 ID 列表（全局，不区分平台）"""
 
     @root_validator(pre=True, allow_reuse=True)
     def set_default_values(cls, values):

--- a/tests/test_wordcloud.py
+++ b/tests/test_wordcloud.py
@@ -735,7 +735,7 @@ async def test_today_wordcloud_exclude_user_ids(
     """测试今日词云，排除特定用户"""
     from nonebot_plugin_wordcloud import plugin_config, wordcloud_cmd
 
-    mocker.patch.object(plugin_config, "wordcloud_exclude_user_ids", {10})
+    mocker.patch.object(plugin_config, "wordcloud_exclude_user_ids", {"10"})
 
     mocked_datetime_now = mocker.patch(
         "nonebot_plugin_wordcloud.get_datetime_now_with_timezone",

--- a/tests/test_wordcloud.py
+++ b/tests/test_wordcloud.py
@@ -727,3 +727,38 @@ async def test_today_wordcloud_qq_group_v12(
 
     mocked_datetime_now.assert_called_once_with()
     mocked_get_wordcloud.assert_called_once_with([], "qq-guild-10000")
+
+
+async def test_today_wordcloud_exclude_user_ids(
+    app: App, mocker: MockerFixture, message_record: None
+):
+    """测试今日词云，排除特定用户"""
+    from nonebot_plugin_wordcloud import plugin_config, wordcloud_cmd
+
+    mocker.patch.object(plugin_config, "wordcloud_exclude_user_ids", {10})
+
+    mocked_datetime_now = mocker.patch(
+        "nonebot_plugin_wordcloud.get_datetime_now_with_timezone",
+        return_value=datetime(2022, 1, 2, 23, tzinfo=ZoneInfo("Asia/Shanghai")),
+    )
+
+    mocked_get_wordcloud = mocker.patch(
+        "nonebot_plugin_wordcloud.get_wordcloud",
+        return_value=FAKE_IMAGE[0],
+    )
+
+    async with app.test_matcher(wordcloud_cmd) as ctx:
+        bot = ctx.create_bot(base=Bot)
+        event = fake_group_message_event_v11(message=Message("/今日词云"))
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(
+            event,
+            MessageSegment.image(FAKE_IMAGE[1]),
+            True,
+            at_sender=False,
+        )
+        ctx.should_finished()
+
+    mocked_datetime_now.assert_called_once_with()
+    mocked_get_wordcloud.assert_called_once_with(["11:1-2"], "qq-group-10000")


### PR DESCRIPTION
可通过在配置添加用户 ID，将其排除在词云外。

```env
wordcloud_exclude_user_ids=["bot_id"]
```