### PR TITLE
fix: 修复定时发送的词云没有排除指定用户的问题

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 
 ## [Unreleased]
 
+### Fixed
+
+- 修复定时发送的词云没有排除指定用户的问题
+
 ## [0.4.9] - 2023-06-27
 
 ### Added

--- a/nonebot_plugin_wordcloud/schedule.py
+++ b/nonebot_plugin_wordcloud/schedule.py
@@ -111,6 +111,7 @@ class Scheduler:
                     types=["message"],
                     time_start=start.astimezone(ZoneInfo("UTC")),
                     time_stop=stop.astimezone(ZoneInfo("UTC")),
+                    exclude_user_ids=plugin_config.wordcloud_exclude_user_ids,
                 )
                 mask_key = get_mask_key(
                     schedule.platform,


### PR DESCRIPTION
修复 <https://github.com/he0119/nonebot-plugin-wordcloud/issues/77#issuecomment-1537450374>。