### PR TITLE
feat: 支持查看被 @ 群友的词云

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -43,30 +43,25 @@
 ## 4. 重要模式与约定
 
 - **命令处理与 Alconna**:
-
   - 命令使用 `Alconna` 进行结构化定义，而不是简单的字符串匹配。例如，在 `__init__.py` 中，`/历史词云` 命令可以接受复杂的日期范围参数。
   - 修改或添加命令时，请遵循 `nonebot-plugin-alconna` 的模式，在 `__init__.py` 中定义 `Alconna` 对象和对应的 `AlconnaMatcher`。
 
 - **会话与用户识别 (UniSession)**:
-
   - 为了跨平台兼容，项目使用 `nonebot-plugin-uninfo` 提供的 `UniSession` 来唯一标识一个会话（私聊或群聊）。
   - 命令处理中的会话信息优先通过依赖注入 `session: Session = UniSession()` 获取。
   - 查询聊天记录时优先调用 `nonebot-plugin-chatrecorder.get_messages_plain_text`，并传入 `session`、`filter_user`、时间范围、排除用户等过滤条件；不要直接查询旧的本插件消息表。
 
 - **发送目标与定时任务 (Target)**:
-
   - 定时发送命令通过 `MessageTarget()` 获取当前 Alconna `Target`。
   - `Schedule.target` 保存 `Target.dump(only_scope=True, save_self_id=False)` 的结果，读取时使用 `Target.load(...)` 还原。
   - 定时任务发送消息时使用 `target.send(UniMessage(Image(...)))` 或 `target.send(UniMessage(Text(...)))`。
   - 根据 `Target` 查询聊天记录时，需要转换出 `scope`、`scene_type`、`scene_id` 等条件，并保持 `filter_self_id=False`、`filter_adapter=False`。
 
 - **遮罩文件 key**:
-
   - `get_mask_key` 同时支持 `nonebot-plugin-uninfo` 的 `Session` 和 Alconna `Target`。
   - key 由平台 scope 和场景路径组成，例如 `QQClient_123456789`；涉及定时任务和普通命令时要保持同一规则。
 
 - **配置**:
-
   - 不要硬编码任何可变值。应将它们添加到 `config.py` 的 `Config` 模型中，并提供合理的默认值。
 
 - **数据存储**:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,29 +35,38 @@
 - **测试**: 测试使用 `pytest`。运行测试的命令定义在 `pyproject.toml` 的 `[tool.poe.tasks]` 部分。
   - 运行所有测试: `poe test`
 - **数据库迁移**: 项目使用 `nonebot-plugin-orm` 管理数据库。如果修改了 `model.py` 中的模型，需要生成新的迁移脚本。
+- **提交与 PR**:
+  - 提交信息和 PR 标题使用约定式提交格式，例如 `feat: 支持查看被 @ 群友的词云`。
+  - PR 标题和正文使用中文，正文需说明变更内容、影响和验证命令。
+  - 涉及用户可见功能、修复或行为变化时，在提交前同步维护 `CHANGELOG.md` 的 `Unreleased` 小节。
 
 ## 4. 重要模式与约定
 
 - **命令处理与 Alconna**:
+
   - 命令使用 `Alconna` 进行结构化定义，而不是简单的字符串匹配。例如，在 `__init__.py` 中，`/历史词云` 命令可以接受复杂的日期范围参数。
   - 修改或添加命令时，请遵循 `nonebot-plugin-alconna` 的模式，在 `__init__.py` 中定义 `Alconna` 对象和对应的 `AlconnaMatcher`。
 
 - **会话与用户识别 (UniSession)**:
+
   - 为了跨平台兼容，项目使用 `nonebot-plugin-uninfo` 提供的 `UniSession` 来唯一标识一个会话（私聊或群聊）。
   - 命令处理中的会话信息优先通过依赖注入 `session: Session = UniSession()` 获取。
   - 查询聊天记录时优先调用 `nonebot-plugin-chatrecorder.get_messages_plain_text`，并传入 `session`、`filter_user`、时间范围、排除用户等过滤条件；不要直接查询旧的本插件消息表。
 
 - **发送目标与定时任务 (Target)**:
+
   - 定时发送命令通过 `MessageTarget()` 获取当前 Alconna `Target`。
   - `Schedule.target` 保存 `Target.dump(only_scope=True, save_self_id=False)` 的结果，读取时使用 `Target.load(...)` 还原。
   - 定时任务发送消息时使用 `target.send(UniMessage(Image(...)))` 或 `target.send(UniMessage(Text(...)))`。
   - 根据 `Target` 查询聊天记录时，需要转换出 `scope`、`scene_type`、`scene_id` 等条件，并保持 `filter_self_id=False`、`filter_adapter=False`。
 
 - **遮罩文件 key**:
+
   - `get_mask_key` 同时支持 `nonebot-plugin-uninfo` 的 `Session` 和 Alconna `Target`。
   - key 由平台 scope 和场景路径组成，例如 `QQClient_123456789`；涉及定时任务和普通命令时要保持同一规则。
 
 - **配置**:
+
   - 不要硬编码任何可变值。应将它们添加到 `config.py` 的 `Config` 模型中，并提供合理的默认值。
 
 - **数据存储**:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/lang/zh-CN/
 - 添加是否默认获取个人数据的配置项
 - 使用 uninfo 与 Alconna Target 管理词云会话
 - 支持周期性词云定时发送并统一完整周期语义
+- 支持超级用户通过 @ 群友查看指定成员词云
 
 ## [0.9.0] - 2025-01-14
 

--- a/nonebot_plugin_wordcloud/__init__.py
+++ b/nonebot_plugin_wordcloud/__init__.py
@@ -26,6 +26,7 @@ from nonebot_plugin_alconna import (
     AlconnaMatcher,
     AlconnaQuery,
     Args,
+    AtID,
     CommandMeta,
     Image,
     Match,
@@ -92,6 +93,8 @@ def get_usage() -> str:
 格式：/<时间段>词云
 时间段关键词有：今日，昨日，本周，上周，本月，上月，年度
 示例：/今日词云，/昨日词云
+超级用户可以通过 @群友 获取该群友的词云
+示例：/今日词云 @群友
 
 - 提供日期与时间，以获取指定时间段内的词云
 （支持 ISO8601 格式的日期与时间，如 2022-02-22T22:22:22）
@@ -200,7 +203,7 @@ wordcloud_cmd = on_alconna(
         ),
         Args["type?", ["今日", "昨日", "本周", "上周", "本月", "上月", "年度", "历史"]][
             "time?", str
-        ],
+        ]["user?", AtID],
         behaviors=[SameTime()],
         meta=CommandMeta(
             description="利用群消息生成词云",
@@ -212,7 +215,8 @@ wordcloud_cmd = on_alconna(
                 "/历史词云\n"
                 "/历史词云 2022-01-01\n"
                 "/历史词云 2022-01-01~2022-02-22\n"
-                "/历史词云 2022-02-22T11:11:11~2022-02-22T22:22:22"
+                "/历史词云 2022-02-22T11:11:11~2022-02-22T22:22:22\n"
+                "/今日词云 @群友"
             ),
         ),
     ),
@@ -367,8 +371,11 @@ async def handle_first_receive(
     parameterless=[Depends(parse_datetime("stop"))],
 )
 async def handle_wordcloud(
+    bot: Bot,
+    event: Event,
     my: Query[bool] = AlconnaQuery("my.value", False),
     group: Query[bool] = AlconnaQuery("group.value", False),
+    user: Match[str] = AlconnaMatch("user"),
     session: Session = UniSession(),
     start: datetime = Arg(),
     stop: datetime = Arg(),
@@ -379,6 +386,7 @@ async def handle_wordcloud(
     Args:
         my: 是否显式查询个人词云。
         group: 是否显式查询群组词云。
+        user: 可选的被 @ 用户 ID。
         session: 当前统一会话信息。
         start: 查询开始时间。
         stop: 查询结束时间。
@@ -396,6 +404,15 @@ async def handle_wordcloud(
         # 使用配置中的默认行为
         filter_user = plugin_config.wordcloud_default_personal
 
+    user_ids = None
+    at_sender = filter_user
+    if user.available:
+        user_ids = [user.result]
+        filter_user = False
+        at_sender = False
+        if user.result != session.user.id and not await SUPERUSER(bot, event):
+            await wordcloud_cmd.finish("仅超级用户可查看其他群友的词云")
+
     messages = await get_messages_plain_text(
         session=session,
         filter_user=filter_user,
@@ -404,19 +421,20 @@ async def handle_wordcloud(
         types=["message"],  # 排除机器人自己发的消息
         time_start=start,
         time_stop=stop,
+        user_ids=user_ids,
         exclude_user_ids=plugin_config.wordcloud_exclude_user_ids,
     )
 
     if not (image := await get_wordcloud(messages, mask_key)):
         await wordcloud_cmd.finish(
             "没有足够的数据生成词云",
-            at_sender=filter_user,
+            at_sender=at_sender,
             reply=plugin_config.wordcloud_reply_message,
         )
 
     await wordcloud_cmd.finish(
         Image(raw=image, name="wordcloud.png"),
-        at_sender=filter_user,
+        at_sender=at_sender,
         reply=plugin_config.wordcloud_reply_message,
     )
 

--- a/tests/test_wordcloud.py
+++ b/tests/test_wordcloud.py
@@ -6,7 +6,7 @@ from zoneinfo import ZoneInfo
 
 import pytest
 from nonebot import get_adapter, get_driver
-from nonebot.adapters.onebot.v11 import Adapter, Bot, Message
+from nonebot.adapters.onebot.v11 import Adapter, Bot, Message, MessageSegment
 from nonebot.adapters.onebot.v12 import Adapter as AdapterV12
 from nonebot.adapters.onebot.v12 import Bot as BotV12
 from nonebot.adapters.onebot.v12 import Message as MessageV12
@@ -343,6 +343,113 @@ async def test_my_today_wordcloud(app: App, mocker: MockerFixture):
             FAKE_IMAGE,
             name="wordcloud.png",
             at_sender=True,
+        )
+        ctx.should_finished()
+
+    mocked_datetime_now.assert_called_once_with()
+    assert_wordcloud_called_with_unordered(
+        mocked_get_wordcloud,
+        {"10:1-2"},
+        "QQClient_10000",
+    )
+
+
+@pytest.mark.usefixtures("_message_record")
+async def test_today_wordcloud_at_user(app: App, mocker: MockerFixture):
+    """测试超级用户查看被 @ 群友的今日词云"""
+    from nonebot import get_driver
+
+    from nonebot_plugin_wordcloud import wordcloud_cmd
+
+    mocker.patch.object(get_driver().config, "superusers", {"10"})
+    mocked_datetime_now = mocker.patch(
+        "nonebot_plugin_wordcloud.get_datetime_now_with_timezone",
+        return_value=datetime(2022, 1, 2, 23, tzinfo=ZoneInfo("Asia/Shanghai")),
+    )
+    mocked_get_wordcloud = mocker.patch(
+        "nonebot_plugin_wordcloud.get_wordcloud",
+        return_value=FAKE_IMAGE,
+    )
+
+    async with app.test_matcher(wordcloud_cmd) as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter, auto_connect=False)
+        event = fake_group_message_event_v11(
+            message=Message("/今日词云 ") + MessageSegment.at(11)
+        )
+
+        ctx.receive_event(bot, event)
+        should_send_image(
+            ctx,
+            bot,
+            event,
+            FAKE_IMAGE,
+            name="wordcloud.png",
+        )
+        ctx.should_finished()
+
+    mocked_datetime_now.assert_called_once_with()
+    assert_wordcloud_called_with_unordered(
+        mocked_get_wordcloud,
+        {"11:1-2"},
+        "QQClient_10000",
+    )
+
+
+@pytest.mark.usefixtures("_message_record")
+async def test_today_wordcloud_at_user_without_permission(app: App, mocker):
+    """测试普通用户不能查看其他群友的今日词云"""
+    from nonebot_plugin_wordcloud import wordcloud_cmd
+
+    mocked_datetime_now = mocker.patch(
+        "nonebot_plugin_wordcloud.get_datetime_now_with_timezone",
+        return_value=datetime(2022, 1, 2, 23, tzinfo=ZoneInfo("Asia/Shanghai")),
+    )
+    mocked_get_wordcloud = mocker.patch("nonebot_plugin_wordcloud.get_wordcloud")
+
+    async with app.test_matcher(wordcloud_cmd) as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter, auto_connect=False)
+        event = fake_group_message_event_v11(
+            message=Message("/今日词云 ") + MessageSegment.at(11)
+        )
+
+        ctx.receive_event(bot, event)
+        ctx.should_call_send(event, "仅超级用户可查看其他群友的词云", True)
+        ctx.should_finished()
+
+    mocked_datetime_now.assert_called_once_with()
+    mocked_get_wordcloud.assert_not_called()
+
+
+@pytest.mark.usefixtures("_message_record")
+async def test_today_wordcloud_at_self(app: App, mocker: MockerFixture):
+    """测试普通用户 @ 自己时查询自己的今日词云"""
+    from nonebot_plugin_wordcloud import wordcloud_cmd
+
+    mocked_datetime_now = mocker.patch(
+        "nonebot_plugin_wordcloud.get_datetime_now_with_timezone",
+        return_value=datetime(2022, 1, 2, 23, tzinfo=ZoneInfo("Asia/Shanghai")),
+    )
+    mocked_get_wordcloud = mocker.patch(
+        "nonebot_plugin_wordcloud.get_wordcloud",
+        return_value=FAKE_IMAGE,
+    )
+
+    async with app.test_matcher(wordcloud_cmd) as ctx:
+        adapter = get_adapter(Adapter)
+        bot = ctx.create_bot(base=Bot, adapter=adapter, auto_connect=False)
+        event = fake_group_message_event_v11(
+            message=Message("/今日词云 ") + MessageSegment.at(10)
+        )
+
+        ctx.receive_event(bot, event)
+        should_send_image(
+            ctx,
+            bot,
+            event,
+            FAKE_IMAGE,
+            name="wordcloud.png",
         )
         ctx.should_finished()
 


### PR DESCRIPTION
支持在生成词云时通过 `@群友` 指定查询对象。命令会在当前群组或频道范围内筛选被 @ 用户的聊天记录；查看其他群友词云需要超级用户权限，普通用户 @ 自己时仍可查询自己的词云。

同时补充了对应测试、更新日志，并把提交与 PR 规范记录到 `AGENTS.md`。

Closes #345